### PR TITLE
[thanos-tools] add flag for uploading compacted blocks to bucket upload-blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#8359](https://github.com/thanos-io/thanos/pull/8359) Tools: add `--shipper.upload-compacted` flag for uploading compacted blocks to bucket upload-blocks
+
 ### Changed
 
 ### Removed

--- a/cmd/thanos/tools_bucket.go
+++ b/cmd/thanos/tools_bucket.go
@@ -166,8 +166,9 @@ type bucketMarkBlockConfig struct {
 }
 
 type bucketUploadBlocksConfig struct {
-	path   string
-	labels []string
+	path            string
+	labels          []string
+	uploadCompacted bool
 }
 
 func (tbc *bucketVerifyConfig) registerBucketVerifyFlag(cmd extkingpin.FlagClause) *bucketVerifyConfig {
@@ -300,6 +301,7 @@ func (tbc *bucketRetentionConfig) registerBucketRetentionFlag(cmd extkingpin.Fla
 func (tbc *bucketUploadBlocksConfig) registerBucketUploadBlocksFlag(cmd extkingpin.FlagClause) *bucketUploadBlocksConfig {
 	cmd.Flag("path", "Path to the directory containing blocks to upload.").Default("./data").StringVar(&tbc.path)
 	cmd.Flag("label", "External labels to add to the uploaded blocks (repeated).").PlaceHolder("key=\"value\"").StringsVar(&tbc.labels)
+	cmd.Flag("shipper.upload-compacted", "If true shipper will try to upload compacted blocks as well.").Default("false").BoolVar(&tbc.uploadCompacted)
 
 	return tbc
 }
@@ -1509,6 +1511,7 @@ func registerBucketUploadBlocks(app extkingpin.AppClause, objStoreConfig *extfla
 			shipper.WithSource(metadata.BucketUploadSource),
 			shipper.WithMetaFileName(shipper.DefaultMetaFilename),
 			shipper.WithLabels(func() labels.Labels { return lset }),
+			shipper.WithUploadCompacted(tbc.uploadCompacted),
 		)
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -1051,6 +1051,8 @@ Flags:
                                upload.
       --label=key="value" ...  External labels to add to the uploaded blocks
                                (repeated).
+      --[no-]shipper.upload-compacted
+                               If true shipper will try to upload compacted blocks as well.
 
 ```
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This is adding the flag `shipper.upload-compacted` to enable uploading compacted blocks using thanos tools. This is the same approach used for the thanos-sidecar already.
- https://github.com/thanos-io/thanos/blob/main/cmd/thanos/config.go#L212-L214

This flag is then used for `upload-blocks` in the `shipper` to set `shipper.WithUploadCompacted`.

## Verification

I have successfully tested this locally. 

Logs without the flag set. We can see the compacted blocks are skipped over.

```
tools bucket upload-blocks \
  --objstore.config='{"type": "s3", "prefix": "thanos-receive/tenant/dev-loadtest-main", "config": {"bucket": "dev-loadtest-main-thanos", "endpoint": "s3.us-west-2.amazonaws.com", "region": "us-west-2"}}' \
  --path="./blocks" \
  --label=tenant_id=\"loadtest-main\"
ts=2025-07-03T21:38:42.703124Z caller=factory.go:54 level=info msg="loading bucket configuration"
ts=2025-07-03T21:38:42.752759Z caller=tools_bucket.go:1521 level=info msg="synced blocks" uploaded=0
ts=2025-07-03T21:38:42.752857Z caller=main.go:174 level=info msg=exiting
```

Logs with the flag set. The compacted blocks are now uploaded.

```
tools bucket upload-blocks \
  --objstore.config='{"type": "s3", "prefix": "thanos-receive/tenant/dev-loadtest-main", "config": {"bucket": "dev-loadtest-main-thanos", "endpoint": "s3.us-west-2.amazonaws.com", "region": "us-west-2"}}' \
  --path="./blocks" \
  --label=tenant_id=\"loadtest-main\" \
  --shipper.upload-compacted
ts=2025-07-03T21:33:25.527097Z caller=factory.go:54 level=info msg="loading bucket configuration"
ts=2025-07-03T21:33:25.531647Z caller=shipper.go:307 level=info msg="no meta file found, creating empty meta data to write later"
ts=2025-07-03T21:33:25.848786Z caller=shipper.go:273 level=info msg="gathering all existing blocks from the remote bucket for check" id=01JZ91KRZ84JWD4X6096T474NQ
ts=2025-07-03T21:37:27.247279Z caller=shipper.go:432 level=info msg="upload new block" id=01JZ91KRZ84JWD4X6096T474NQ
ts=2025-07-03T21:37:27.940023Z caller=shipper.go:432 level=info msg="upload new block"
```
